### PR TITLE
Add spring-web to pom.xml

### DIFF
--- a/spring-social-movies/pom.xml
+++ b/spring-social-movies/pom.xml
@@ -30,6 +30,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
+			<version>${org.springframework-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
 			<version>${org.springframework-version}</version>
 		</dependency>

--- a/spring-social-popup/pom.xml
+++ b/spring-social-popup/pom.xml
@@ -32,6 +32,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
+			<version>${org.springframework-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
 			<version>${org.springframework-version}</version>
 		</dependency>

--- a/spring-social-twitter4j/pom.xml
+++ b/spring-social-twitter4j/pom.xml
@@ -30,6 +30,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
+			<version>${org.springframework-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
 			<version>${org.springframework-version}</version>
 		</dependency>


### PR DESCRIPTION
Previously spring-web 3.1.x was brought in transitively which
caused compilation errors stating HandlerMethodReturnValueHandler
cannot be resolved.

Now spring-web is explicitly listed in the pom's that were having
issues.
