### PR TITLE
Fix UTF-8 support (Maven configuration & template rendered)

### DIFF
--- a/spring-social-showcase/pom.xml
+++ b/spring-social-showcase/pom.xml
@@ -8,6 +8,7 @@
 	<packaging>war</packaging>
 	<version>1.0.0</version>
 	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java-version>1.6</java-version>
 		<org.springframework.social-version>1.1.0.RC1</org.springframework.social-version>
 		<org.springframework.social.facebook-version>1.1.0.RC1</org.springframework.social.facebook-version>
@@ -39,11 +40,6 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
-			<version>${org.springframework-version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-web</artifactId>
 			<version>${org.springframework-version}</version>
 		</dependency>
 		<dependency>

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/config/WebMvcConfig.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/config/WebMvcConfig.java
@@ -17,6 +17,7 @@ package org.springframework.social.showcase.config;
 
 import nz.net.ultraq.thymeleaf.LayoutDialect;
 
+import org.apache.commons.codec.CharEncoding;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -56,6 +57,8 @@ public class WebMvcConfig extends WebMvcConfigurerAdapter {
 	public ViewResolver viewResolver(SpringTemplateEngine templateEngine) {
 		ThymeleafViewResolver viewResolver = new ThymeleafViewResolver();
 		viewResolver.setTemplateEngine(templateEngine);
+		viewResolver.setCharacterEncoding(CharEncoding.UTF_8);
+		viewResolver.setContentType("text/html; charset=utf-8");
 		return viewResolver;
 	}
 
@@ -74,6 +77,7 @@ public class WebMvcConfig extends WebMvcConfigurerAdapter {
 		templateResolver.setPrefix("/WEB-INF/views/");
 		templateResolver.setSuffix(".html");
 		templateResolver.setTemplateMode("HTML5");
+		templateResolver.setCharacterEncoding(CharEncoding.UTF_8);
 		return templateResolver;
 	}
 }


### PR DESCRIPTION
There are some problems with Cyrillic symbols and ThymeleafViewResolver.
AbstractThymeleafView does not use UTF-8 by default (see AbstractThymeleafView.DEFAULT_CONTENT_TYPE)

This patch helps to resolve it.
