### PR TITLE
Update MainConfig.java

### DIFF
--- a/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/config/MainConfig.java
+++ b/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/config/MainConfig.java
@@ -66,7 +66,7 @@ public class MainConfig {
 	}
 
 	@Bean
-	public PropertySourcesPlaceholderConfigurer propertyPlaceHolderConfigurer() {
+	public static PropertySourcesPlaceholderConfigurer propertyPlaceHolderConfigurer() {
 		return new PropertySourcesPlaceholderConfigurer();
 	}
 	


### PR DESCRIPTION
WARN : org.springframework.context.annotation.ConfigurationClassEnhancer - @Bean method MainConfig.propertyPlaceHolderConfigurer is non-static and returns an object assignable to Spring's BeanFactoryPostProcessor interface. This will result in a failure to process annotations such as @Autowired, @Resource and @PostConstruct within the method's declaring @Configuration class. Add the 'static' modifier to this method to avoid these container lifecycle issues; see @Bean Javadoc for complete details
