### PR TITLE
Added snapshot repository

### DIFF
--- a/spring-social-showcase-boot/build.gradle
+++ b/spring-social-showcase-boot/build.gradle
@@ -27,6 +27,7 @@ eclipse {
 
 repositories {
   mavenLocal()
+  maven { url "http://repo.spring.io/snapshot" }
   maven { url "http://repo.spring.io/milestone" }
   mavenCentral()
   maven { url "http://repo.spring.io/libs-milestone" }


### PR DESCRIPTION
Needed to build spring-social-showcase-boot with the spring-social-config:1.2.0.BUILD-SNAPSHOT dependency.