### PR TITLE
URL Cleanup

### DIFF
--- a/attic/spring-social-canvas/build.gradle
+++ b/attic/spring-social-canvas/build.gradle
@@ -48,10 +48,10 @@ dependencies {
 
 repositories {
 	mavenLocal()
-	maven { url 'http://maven.springframework.org/release' }
-	maven { url 'http://maven.springframework.org/milestone' }
-	maven { url 'http://maven.springframework.org/snapshot' }
-	maven { url 'http://download.java.net/maven/2' }
+	maven { url 'https://maven.springframework.org/release' }
+	maven { url 'https://maven.springframework.org/milestone' }
+	maven { url 'https://maven.springframework.org/snapshot' }
+	maven { url 'https://download.java.net/maven/2' }
 	mavenCentral()
 }
 

--- a/attic/spring-social-movies/pom.xml
+++ b/attic/spring-social-movies/pom.xml
@@ -187,7 +187,7 @@
 		<repository>
 			<id>org.springframework.maven.release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://repo.springsource.org/libs-release-local</url>
+			<url>https://repo.springsource.org/libs-release-local</url>
 			<releases><enabled>true</enabled></releases>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
@@ -195,7 +195,7 @@
 		<repository>
 			<id>org.springframework.maven.snapshot</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/libs-snapshot-local</url>
+			<url>https://repo.springsource.org/libs-snapshot-local</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -203,7 +203,7 @@
 		<repository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://repo.springsource.org/libs-milestone-local</url>
+			<url>https://repo.springsource.org/libs-milestone-local</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/attic/spring-social-popup/pom.xml
+++ b/attic/spring-social-popup/pom.xml
@@ -183,7 +183,7 @@
 		<repository>
 			<id>org.springframework.maven.release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://repo.springsource.org/libs-release-local</url>
+			<url>https://repo.springsource.org/libs-release-local</url>
 			<releases><enabled>true</enabled></releases>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
@@ -191,7 +191,7 @@
 		<repository>
 			<id>org.springframework.maven.snapshot</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/libs-snapshot-local</url>
+			<url>https://repo.springsource.org/libs-snapshot-local</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -199,7 +199,7 @@
 		<repository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://repo.springsource.org/libs-milestone-local</url>
+			<url>https://repo.springsource.org/libs-milestone-local</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/attic/spring-social-quickstart-3.0.x/pom.xml
+++ b/attic/spring-social-quickstart-3.0.x/pom.xml
@@ -83,7 +83,7 @@
 		<repository>
 			<id>org.springframework.maven.release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://repo.springsource.org/libs-release-local</url>
+			<url>https://repo.springsource.org/libs-release-local</url>
 			<releases><enabled>true</enabled></releases>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
@@ -91,7 +91,7 @@
 		<repository>
 			<id>org.springframework.maven.snapshot</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/libs-snapshot-local</url>
+			<url>https://repo.springsource.org/libs-snapshot-local</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -99,7 +99,7 @@
 		<repository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://repo.springsource.org/libs-milestone-local</url>
+			<url>https://repo.springsource.org/libs-milestone-local</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/attic/spring-social-showcase-implicit/build.gradle
+++ b/attic/spring-social-showcase-implicit/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   repositories {
-    maven { url "http://repo.spring.io/libs-snapshot" }
+    maven { url "https://repo.spring.io/libs-snapshot" }
     mavenLocal()
   }
   dependencies {
@@ -27,7 +27,7 @@ eclipse {
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { url "http://repo.spring.io/libs-milestone" }
+  maven { url "https://repo.spring.io/libs-milestone" }
 }
 
 dependencies {

--- a/attic/spring-social-showcase-sec-xml/pom.xml
+++ b/attic/spring-social-showcase-sec-xml/pom.xml
@@ -219,7 +219,7 @@
 		<repository>
 			<id>org.springframework.maven.release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://repo.springsource.org/release</url>
+			<url>https://repo.springsource.org/release</url>
 			<releases><enabled>true</enabled></releases>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
@@ -227,7 +227,7 @@
 		<repository>
 			<id>org.springframework.maven.snapshot</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -235,7 +235,7 @@
 		<repository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://repo.springsource.org/milestone</url>
+			<url>https://repo.springsource.org/milestone</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/attic/spring-social-showcase-sec/build.gradle
+++ b/attic/spring-social-showcase-sec/build.gradle
@@ -61,11 +61,11 @@ dependencies {
 
 repositories {
 	mavenLocal()
-	maven { url 'http://repo.spring.io/libs-staging-local'}
-	maven { url 'http://repo.spring.io/release' }
-	maven { url 'http://repo.spring.io/milestone' }
-	maven { url 'http://repo.spring.io/snapshot' }
-	maven { url 'http://download.java.net/maven/2' }
+	maven { url 'https://repo.spring.io/libs-staging-local'}
+	maven { url 'https://repo.spring.io/release' }
+	maven { url 'https://repo.spring.io/milestone' }
+	maven { url 'https://repo.spring.io/snapshot' }
+	maven { url 'https://download.java.net/maven/2' }
 	mavenCentral()
 }
 

--- a/attic/spring-social-showcase-xml/pom.xml
+++ b/attic/spring-social-showcase-xml/pom.xml
@@ -207,7 +207,7 @@
 		<repository>
 			<id>org.springframework.maven.release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://repo.springsource.org/release</url>
+			<url>https://repo.springsource.org/release</url>
 			<releases><enabled>true</enabled></releases>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
@@ -215,7 +215,7 @@
 		<repository>
 			<id>org.springframework.maven.snapshot</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -223,7 +223,7 @@
 		<repository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://repo.springsource.org/milestone</url>
+			<url>https://repo.springsource.org/milestone</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/attic/spring-social-showcase/build.gradle
+++ b/attic/spring-social-showcase/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'tomcat'
 
 buildscript {
     repositories {
-        maven { url "http://repo.spring.io/milestone" }
+        maven { url "https://repo.spring.io/milestone" }
         mavenCentral()
     }
 
@@ -63,10 +63,10 @@ dependencies {
 
 repositories {
 	mavenLocal()
-	maven { url 'http://repo.spring.io/release' }
-	maven { url 'http://repo.spring.io/milestone' }
-	maven { url 'http://repo.spring.io/snapshot' }
-	maven { url 'http://download.java.net/maven/2' }
+	maven { url 'https://repo.spring.io/release' }
+	maven { url 'https://repo.spring.io/milestone' }
+	maven { url 'https://repo.spring.io/snapshot' }
+	maven { url 'https://download.java.net/maven/2' }
 	mavenCentral()
 }
 

--- a/attic/spring-social-twitter4j/pom.xml
+++ b/attic/spring-social-twitter4j/pom.xml
@@ -161,7 +161,7 @@
 		<repository>
 			<id>org.springframework.maven.release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://maven.springframework.org/release</url>
+			<url>https://maven.springframework.org/release</url>
 			<releases><enabled>true</enabled></releases>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
@@ -169,7 +169,7 @@
 		<repository>
 			<id>org.springframework.maven.snapshot</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -177,7 +177,7 @@
 		<repository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/spring-social-quickstart/build.gradle
+++ b/spring-social-quickstart/build.gradle
@@ -50,10 +50,10 @@ dependencies {
 
 repositories {
 	mavenLocal()
-	maven { url 'http://maven.springframework.org/release' }
-	maven { url 'http://maven.springframework.org/milestone' }
-	maven { url 'http://maven.springframework.org/snapshot' }
-	maven { url 'http://download.java.net/maven/2' }
+	maven { url 'https://maven.springframework.org/release' }
+	maven { url 'https://maven.springframework.org/milestone' }
+	maven { url 'https://maven.springframework.org/snapshot' }
+	maven { url 'https://download.java.net/maven/2' }
 	mavenCentral()
 }
 

--- a/spring-social-showcase/build.gradle
+++ b/spring-social-showcase/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   repositories {
-    maven { url "http://repo.spring.io/libs-milestone" }
-    maven { url "http://repo.spring.io/libs-snapshot" }
+    maven { url "https://repo.spring.io/libs-milestone" }
+    maven { url "https://repo.spring.io/libs-snapshot" }
     mavenLocal()
   }
   dependencies {
@@ -26,9 +26,9 @@ eclipse {
 
 repositories {
   mavenLocal()
-  maven { url "http://repo.spring.io/milestone" }
+  maven { url "https://repo.spring.io/milestone" }
   mavenCentral()
-  maven { url "http://repo.spring.io/libs-milestone" }
+  maven { url "https://repo.spring.io/libs-milestone" }
 }
 
 dependencies {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://download.java.net/maven/2 (301) migrated to:  
  https://download.java.net/maven/2 ([https](https://download.java.net/maven/2) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://repo.springsource.org/libs-milestone-local migrated to:  
  https://repo.springsource.org/libs-milestone-local ([https](https://repo.springsource.org/libs-milestone-local) result 301).
* http://repo.springsource.org/libs-release-local migrated to:  
  https://repo.springsource.org/libs-release-local ([https](https://repo.springsource.org/libs-release-local) result 301).
* http://repo.springsource.org/libs-snapshot-local migrated to:  
  https://repo.springsource.org/libs-snapshot-local ([https](https://repo.springsource.org/libs-snapshot-local) result 301).
* http://repo.springsource.org/milestone migrated to:  
  https://repo.springsource.org/milestone ([https](https://repo.springsource.org/milestone) result 301).
* http://repo.springsource.org/release migrated to:  
  https://repo.springsource.org/release ([https](https://repo.springsource.org/release) result 301).
* http://repo.springsource.org/snapshot migrated to:  
  https://repo.springsource.org/snapshot ([https](https://repo.springsource.org/snapshot) result 301).
* http://maven.springframework.org/milestone migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/release migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).
* http://maven.springframework.org/snapshot migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result 302).
* http://repo.spring.io/libs-milestone migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/libs-snapshot migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/libs-staging-local migrated to:  
  https://repo.spring.io/libs-staging-local ([https](https://repo.spring.io/libs-staging-local) result 302).
* http://repo.spring.io/milestone migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* http://repo.spring.io/release migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).
* http://repo.spring.io/snapshot migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance