### PR TITLE
URL Cleanup

### DIFF
--- a/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/config/MainConfig.java
+++ b/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/config/MainConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/config/SocialConfig.java
+++ b/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/config/SocialConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/config/WebMvcConfig.java
+++ b/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/config/WebMvcConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/user/SecurityContext.java
+++ b/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/user/SecurityContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/user/SimpleConnectionSignUp.java
+++ b/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/user/SimpleConnectionSignUp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/user/SimpleSignInAdapter.java
+++ b/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/user/SimpleSignInAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/user/User.java
+++ b/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/user/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/user/UserCookieGenerator.java
+++ b/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/user/UserCookieGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/user/UserInterceptor.java
+++ b/attic/spring-social-canvas/src/main/java/org/springframework/social/canvas/user/UserInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/HomeController.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/account/Account.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/account/Account.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/account/AccountRepository.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/account/AccountRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/account/JdbcAccountRepository.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/account/JdbcAccountRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/account/UsernameAlreadyInUseException.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/account/UsernameAlreadyInUseException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/config/MainConfig.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/config/MainConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/config/SecurityConfig.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/config/SecurityConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/config/SocialConfig.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/config/SocialConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/config/WebMvcConfig.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/config/WebMvcConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/api/CatalogTitle.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/api/CatalogTitle.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/api/NetFlixApi.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/api/NetFlixApi.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/api/NetFlixUserProfile.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/api/NetFlixUserProfile.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/api/QueueItem.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/api/QueueItem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/api/impl/NetFlixModule.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/api/impl/NetFlixModule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/api/impl/NetFlixTemplate.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/api/impl/NetFlixTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/api/impl/NetFlixUserProfileMixin.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/api/impl/NetFlixUserProfileMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/connect/NetFlixApiAdapter.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/connect/NetFlixApiAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/connect/NetFlixConnectionFactory.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/connect/NetFlixConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/connect/NetFlixOAuth1Template.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/connect/NetFlixOAuth1Template.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/connect/NetFlixServiceProvider.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/netflix/connect/NetFlixServiceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/review/JdbcReviewRepository.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/review/JdbcReviewRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/review/Review.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/review/Review.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/review/ReviewController.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/review/ReviewController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/review/ReviewForm.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/review/ReviewForm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/review/ReviewRepository.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/review/ReviewRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/review/ReviewRowMapper.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/review/ReviewRowMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/signin/SignInUtils.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/signin/SignInUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/signin/SigninController.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/signin/SigninController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/signup/SignupController.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/signup/SignupController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-movies/src/main/java/org/springframework/social/movies/signup/SignupForm.java
+++ b/attic/spring-social-movies/src/main/java/org/springframework/social/movies/signup/SignupForm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/HomeController.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/account/Account.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/account/Account.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/account/AccountRepository.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/account/AccountRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/account/JdbcAccountRepository.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/account/JdbcAccountRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/account/UsernameAlreadyInUseException.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/account/UsernameAlreadyInUseException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/config/MainConfig.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/config/MainConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/config/SecurityConfig.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/config/SecurityConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/config/SocialConfig.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/config/SocialConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/config/WebMvcConfig.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/config/WebMvcConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/connect/SinglePageConnectController.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/connect/SinglePageConnectController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/facebook/FacebookProfileController.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/facebook/FacebookProfileController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/facebook/PopupDialogConnectInterceptor.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/facebook/PopupDialogConnectInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/facebook/PostToWallAfterConnectInterceptor.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/facebook/PostToWallAfterConnectInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/message/Message.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/message/Message.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/message/MessageType.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/message/MessageType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/signin/SignInUtils.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/signin/SignInUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/signin/SigninController.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/signin/SigninController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/signup/SignupController.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/signup/SignupController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/signup/SignupForm.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/signup/SignupForm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/twitter/MessageForm.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/twitter/MessageForm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/twitter/TweetAfterConnectInterceptor.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/twitter/TweetAfterConnectInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-popup/src/main/java/org/springframework/social/popup/twitter/TwitterProfileController.java
+++ b/attic/spring-social-popup/src/main/java/org/springframework/social/popup/twitter/TwitterProfileController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-quickstart-3.0.x/src/main/java/org/springframework/social/quickstart/HomeController.java
+++ b/attic/spring-social-quickstart-3.0.x/src/main/java/org/springframework/social/quickstart/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-quickstart-3.0.x/src/main/java/org/springframework/social/quickstart/config/SocialConfig.java
+++ b/attic/spring-social-quickstart-3.0.x/src/main/java/org/springframework/social/quickstart/config/SocialConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-quickstart-3.0.x/src/main/java/org/springframework/social/quickstart/user/SecurityContext.java
+++ b/attic/spring-social-quickstart-3.0.x/src/main/java/org/springframework/social/quickstart/user/SecurityContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-quickstart-3.0.x/src/main/java/org/springframework/social/quickstart/user/SimpleConnectionSignUp.java
+++ b/attic/spring-social-quickstart-3.0.x/src/main/java/org/springframework/social/quickstart/user/SimpleConnectionSignUp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-quickstart-3.0.x/src/main/java/org/springframework/social/quickstart/user/SimpleSignInAdapter.java
+++ b/attic/spring-social-quickstart-3.0.x/src/main/java/org/springframework/social/quickstart/user/SimpleSignInAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-quickstart-3.0.x/src/main/java/org/springframework/social/quickstart/user/User.java
+++ b/attic/spring-social-quickstart-3.0.x/src/main/java/org/springframework/social/quickstart/user/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-quickstart-3.0.x/src/main/java/org/springframework/social/quickstart/user/UserCookieGenerator.java
+++ b/attic/spring-social-quickstart-3.0.x/src/main/java/org/springframework/social/quickstart/user/UserCookieGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-quickstart-3.0.x/src/main/java/org/springframework/social/quickstart/user/UserInterceptor.java
+++ b/attic/spring-social-quickstart-3.0.x/src/main/java/org/springframework/social/quickstart/user/UserInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/HomeController.java
+++ b/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/config/SecurityConfig.java
+++ b/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/config/SecurityConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/facebook/FacebookExpiredToken.java
+++ b/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/facebook/FacebookExpiredToken.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/facebook/FacebookFeedController.java
+++ b/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/facebook/FacebookFeedController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/facebook/FacebookPhotosController.java
+++ b/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/facebook/FacebookPhotosController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/facebook/FacebookProfileController.java
+++ b/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/facebook/FacebookProfileController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/facebook/PostToWallAfterConnectInterceptor.java
+++ b/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/facebook/PostToWallAfterConnectInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/signin/ImplicitSignInAdapter.java
+++ b/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/signin/ImplicitSignInAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/signin/SignInUtils.java
+++ b/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/signin/SignInUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/signin/SigninController.java
+++ b/attic/spring-social-showcase-implicit/src/main/java/org/springframework/social/showcase/signin/SigninController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/HomeController.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/account/Account.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/account/Account.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/account/AccountRepository.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/account/AccountRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/account/JdbcAccountRepository.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/account/JdbcAccountRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/account/UsernameAlreadyInUseException.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/account/UsernameAlreadyInUseException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/config/MainConfig.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/config/MainConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/config/SecurityConfig.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/config/SecurityConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/config/SecurityWebInitializer.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/config/SecurityWebInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/config/SocialConfig.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/config/SocialConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/config/SpringMvcInitializer.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/config/SpringMvcInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/config/WebMvcConfig.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/config/WebMvcConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/facebook/FacebookExpiredToken.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/facebook/FacebookExpiredToken.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/facebook/FacebookFeedController.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/facebook/FacebookFeedController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/facebook/FacebookFriendsController.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/facebook/FacebookFriendsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/facebook/FacebookPhotosController.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/facebook/FacebookPhotosController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/facebook/FacebookProfileController.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/facebook/FacebookProfileController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/facebook/PostToWallAfterConnectInterceptor.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/facebook/PostToWallAfterConnectInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/message/Message.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/message/Message.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/message/MessageType.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/message/MessageType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/signin/SignInUtils.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/signin/SignInUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/signin/SigninController.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/signin/SigninController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/signin/SimpleSignInAdapter.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/signin/SimpleSignInAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/signup/SignupController.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/signup/SignupController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/signup/SignupForm.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/signup/SignupForm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/MessageForm.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/MessageForm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/TweetAfterConnectInterceptor.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/TweetAfterConnectInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/TwitterFriendsController.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/TwitterFriendsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/TwitterMessageController.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/TwitterMessageController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/TwitterProfileController.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/TwitterProfileController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/TwitterRevokedToken.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/TwitterRevokedToken.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/TwitterSearchController.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/TwitterSearchController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/TwitterTimelineController.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/TwitterTimelineController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/TwitterTrendsController.java
+++ b/attic/spring-social-showcase-javaconfig/src/main/java/org/springframework/social/showcase/twitter/TwitterTrendsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/HomeController.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/account/Account.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/account/Account.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/account/AccountRepository.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/account/AccountRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/account/JdbcAccountRepository.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/account/JdbcAccountRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/account/UsernameAlreadyInUseException.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/account/UsernameAlreadyInUseException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/facebook/FacebookFeedController.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/facebook/FacebookFeedController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/facebook/FacebookFriendsController.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/facebook/FacebookFriendsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/facebook/FacebookPhotosController.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/facebook/FacebookPhotosController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/facebook/FacebookProfileController.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/facebook/FacebookProfileController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/facebook/PostToWallAfterConnectInterceptor.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/facebook/PostToWallAfterConnectInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/linkedin/LinkedInProfileController.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/linkedin/LinkedInProfileController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/message/Message.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/message/Message.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/message/MessageType.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/message/MessageType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/signin/SignInUtils.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/signin/SignInUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/signin/SigninController.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/signin/SigninController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/signin/SimpleSignInAdapter.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/signin/SimpleSignInAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/signup/SignupController.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/signup/SignupController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/signup/SignupForm.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/signup/SignupForm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/twitter/MessageForm.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/twitter/MessageForm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/twitter/TweetAfterConnectInterceptor.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/twitter/TweetAfterConnectInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/twitter/TwitterFriendsController.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/twitter/TwitterFriendsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/twitter/TwitterMessageController.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/twitter/TwitterMessageController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/twitter/TwitterProfileController.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/twitter/TwitterProfileController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/twitter/TwitterSearchController.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/twitter/TwitterSearchController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/twitter/TwitterTimelineController.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/twitter/TwitterTimelineController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/twitter/TwitterTrendsController.java
+++ b/attic/spring-social-showcase-sec-xml/src/main/java/org/springframework/social/showcase/twitter/TwitterTrendsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/HomeController.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/account/Account.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/account/Account.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/account/AccountRepository.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/account/AccountRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/account/JdbcAccountRepository.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/account/JdbcAccountRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/account/UsernameAlreadyInUseException.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/account/UsernameAlreadyInUseException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/config/MainConfig.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/config/MainConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/config/SecurityConfig.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/config/SecurityConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/config/SocialConfig.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/config/SocialConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/config/WebMvcConfig.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/config/WebMvcConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/facebook/FacebookFeedController.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/facebook/FacebookFeedController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/facebook/FacebookFriendsController.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/facebook/FacebookFriendsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/facebook/FacebookPhotosController.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/facebook/FacebookPhotosController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/facebook/FacebookProfileController.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/facebook/FacebookProfileController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/facebook/PostToWallAfterConnectInterceptor.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/facebook/PostToWallAfterConnectInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/linkedin/LinkedInProfileController.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/linkedin/LinkedInProfileController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/message/Message.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/message/Message.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/message/MessageType.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/message/MessageType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/signin/SignInUtils.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/signin/SignInUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/signin/SigninController.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/signin/SigninController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/signin/SimpleSignInAdapter.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/signin/SimpleSignInAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/signup/SignupController.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/signup/SignupController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/signup/SignupForm.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/signup/SignupForm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/twitter/MessageForm.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/twitter/MessageForm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/twitter/TweetAfterConnectInterceptor.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/twitter/TweetAfterConnectInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/twitter/TwitterFriendsController.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/twitter/TwitterFriendsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/twitter/TwitterMessageController.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/twitter/TwitterMessageController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/twitter/TwitterProfileController.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/twitter/TwitterProfileController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/twitter/TwitterSearchController.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/twitter/TwitterSearchController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/twitter/TwitterTimelineController.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/twitter/TwitterTimelineController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/twitter/TwitterTrendsController.java
+++ b/attic/spring-social-showcase-sec/src/main/java/org/springframework/social/showcase/twitter/TwitterTrendsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/HomeController.java
+++ b/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/account/Account.java
+++ b/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/account/Account.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/account/AccountRepository.java
+++ b/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/account/AccountRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/account/JdbcAccountRepository.java
+++ b/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/account/JdbcAccountRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/account/UsernameAlreadyInUseException.java
+++ b/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/account/UsernameAlreadyInUseException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/facebook/FacebookFeedController.java
+++ b/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/facebook/FacebookFeedController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/facebook/FacebookFriendsController.java
+++ b/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/facebook/FacebookFriendsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/facebook/FacebookPhotosController.java
+++ b/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/facebook/FacebookPhotosController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/facebook/FacebookProfileController.java
+++ b/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/facebook/FacebookProfileController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/facebook/PostToWallAfterConnectInterceptor.java
+++ b/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/facebook/PostToWallAfterConnectInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/message/Message.java
+++ b/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/message/Message.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/message/MessageType.java
+++ b/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/message/MessageType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/signin/SignInUtils.java
+++ b/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/signin/SignInUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/signin/SigninController.java
+++ b/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/signin/SigninController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/signin/SimpleSignInAdapter.java
+++ b/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/signin/SimpleSignInAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/signup/SignupController.java
+++ b/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/signup/SignupController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/signup/SignupForm.java
+++ b/attic/spring-social-showcase-xml/src/main/java/org/springframework/social/showcase/signup/SignupForm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/HomeController.java
+++ b/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/account/Account.java
+++ b/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/account/Account.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/account/AccountRepository.java
+++ b/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/account/AccountRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/account/JdbcAccountRepository.java
+++ b/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/account/JdbcAccountRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/account/UsernameAlreadyInUseException.java
+++ b/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/account/UsernameAlreadyInUseException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/signin/SigninController.java
+++ b/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/signin/SigninController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/signup/SignupController.java
+++ b/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/signup/SignupController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/signup/SignupForm.java
+++ b/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/signup/SignupForm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/twitter/TweetAfterConnectInterceptor.java
+++ b/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/twitter/TweetAfterConnectInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/twitter/TweetController.java
+++ b/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/twitter/TweetController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/twitter/connect/TwitterApiAdapter.java
+++ b/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/twitter/connect/TwitterApiAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/twitter/connect/TwitterConnectionFactory.java
+++ b/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/twitter/connect/TwitterConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/twitter/connect/TwitterServiceProvider.java
+++ b/attic/spring-social-twitter4j/src/main/java/org/springframework/social/showcase/twitter/connect/TwitterServiceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/HomeController.java
+++ b/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/config/MainConfig.java
+++ b/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/config/MainConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/config/SocialConfig.java
+++ b/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/config/SocialConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/config/WebConfig.java
+++ b/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/config/WebConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/config/WebMvcConfig.java
+++ b/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/config/WebMvcConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/user/SecurityContext.java
+++ b/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/user/SecurityContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/user/SimpleConnectionSignUp.java
+++ b/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/user/SimpleConnectionSignUp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/user/SimpleSignInAdapter.java
+++ b/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/user/SimpleSignInAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/user/User.java
+++ b/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/user/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/user/UserCookieGenerator.java
+++ b/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/user/UserCookieGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/user/UserInterceptor.java
+++ b/spring-social-quickstart/src/main/java/org/springframework/social/quickstart/user/UserInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/HomeController.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/account/Account.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/account/Account.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/account/AccountRepository.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/account/AccountRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/account/JdbcAccountRepository.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/account/JdbcAccountRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/account/UsernameAlreadyInUseException.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/account/UsernameAlreadyInUseException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/config/SecurityConfig.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/config/SecurityConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/facebook/FacebookExpiredToken.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/facebook/FacebookExpiredToken.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/facebook/FacebookFeedController.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/facebook/FacebookFeedController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/facebook/FacebookFriendsController.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/facebook/FacebookFriendsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/facebook/FacebookPhotosController.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/facebook/FacebookPhotosController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/facebook/FacebookProfileController.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/facebook/FacebookProfileController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/facebook/PostToWallAfterConnectInterceptor.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/facebook/PostToWallAfterConnectInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/message/Message.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/message/Message.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/message/MessageType.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/message/MessageType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/signin/SignInUtils.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/signin/SignInUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/signin/SigninController.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/signin/SigninController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/signup/SignupController.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/signup/SignupController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/signup/SignupForm.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/signup/SignupForm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/twitter/MessageForm.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/twitter/MessageForm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/twitter/TweetAfterConnectInterceptor.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/twitter/TweetAfterConnectInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/twitter/TwitterFriendsController.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/twitter/TwitterFriendsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/twitter/TwitterProfileController.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/twitter/TwitterProfileController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/twitter/TwitterRevokedToken.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/twitter/TwitterRevokedToken.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/twitter/TwitterSearchController.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/twitter/TwitterSearchController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/twitter/TwitterTimelineController.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/twitter/TwitterTimelineController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-showcase/src/main/java/org/springframework/social/showcase/twitter/TwitterTrendsController.java
+++ b/spring-social-showcase/src/main/java/org/springframework/social/showcase/twitter/TwitterTrendsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 235 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).