### PR TITLE
URL Cleanup

### DIFF
--- a/attic/spring-social-canvas/build.gradle
+++ b/attic/spring-social-canvas/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'tomcat'
 
 buildscript {
     repositories {
-        mavenCentral()
+        maven { url 'https://repo.maven.apache.org/maven2/' }
     }
 
     dependencies {
@@ -52,7 +52,7 @@ repositories {
 	maven { url 'http://maven.springframework.org/milestone' }
 	maven { url 'http://maven.springframework.org/snapshot' }
 	maven { url 'http://download.java.net/maven/2' }
-	mavenCentral()
+	maven { url 'https://repo.maven.apache.org/maven2/' }
 }
 
 task wrapper(type: Wrapper) {

--- a/attic/spring-social-canvas/gradle/wrapper/gradle-wrapper.properties
+++ b/attic/spring-social-canvas/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-1.11-bin.zip

--- a/attic/spring-social-showcase-implicit/build.gradle
+++ b/attic/spring-social-showcase-implicit/build.gradle
@@ -26,7 +26,7 @@ eclipse {
 
 repositories {
   mavenLocal()
-  mavenCentral()
+  maven { url 'https://repo.maven.apache.org/maven2/' }
   maven { url "http://repo.spring.io/libs-milestone" }
 }
 

--- a/attic/spring-social-showcase-javaconfig/build.gradle
+++ b/attic/spring-social-showcase-javaconfig/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'tomcat'
 buildscript {
     repositories {
         maven { url "http://repo.spring.io/milestone" }
-        mavenCentral()
+        maven { url 'https://repo.maven.apache.org/maven2/' }
     }
 
     dependencies {
@@ -67,7 +67,7 @@ repositories {
 	maven { url 'http://repo.spring.io/milestone' }
 	maven { url 'http://repo.spring.io/snapshot' }
 	maven { url 'http://download.java.net/maven/2' }
-	mavenCentral()
+	maven { url 'https://repo.maven.apache.org/maven2/' }
 }
 
 task wrapper(type: Wrapper) {

--- a/attic/spring-social-showcase-javaconfig/gradle/wrapper/gradle-wrapper.properties
+++ b/attic/spring-social-showcase-javaconfig/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-1.11-bin.zip

--- a/attic/spring-social-showcase-sec/build.gradle
+++ b/attic/spring-social-showcase-sec/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'tomcat'
 
 buildscript {
     repositories {
-        mavenCentral()
+        maven { url 'https://repo.maven.apache.org/maven2/' }
     }
 
     dependencies {
@@ -66,7 +66,7 @@ repositories {
 	maven { url 'http://repo.spring.io/milestone' }
 	maven { url 'http://repo.spring.io/snapshot' }
 	maven { url 'http://download.java.net/maven/2' }
-	mavenCentral()
+	maven { url 'https://repo.maven.apache.org/maven2/' }
 }
 
 task wrapper(type: Wrapper) {

--- a/attic/spring-social-showcase-sec/gradle/wrapper/gradle-wrapper.properties
+++ b/attic/spring-social-showcase-sec/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-1.11-bin.zip

--- a/spring-social-quickstart/build.gradle
+++ b/spring-social-quickstart/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'tomcat'
 
 buildscript {
     repositories {
-        mavenCentral()
+        maven { url 'https://repo.maven.apache.org/maven2/' }
     }
 
     dependencies {
@@ -54,7 +54,7 @@ repositories {
 	maven { url 'http://maven.springframework.org/milestone' }
 	maven { url 'http://maven.springframework.org/snapshot' }
 	maven { url 'http://download.java.net/maven/2' }
-	mavenCentral()
+	maven { url 'https://repo.maven.apache.org/maven2/' }
 }
 
 task wrapper(type: Wrapper) {

--- a/spring-social-quickstart/gradle/wrapper/gradle-wrapper.properties
+++ b/spring-social-quickstart/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-1.11-bin.zip

--- a/spring-social-showcase/build.gradle
+++ b/spring-social-showcase/build.gradle
@@ -27,7 +27,7 @@ eclipse {
 repositories {
   mavenLocal()
   maven { url "http://repo.spring.io/milestone" }
-  mavenCentral()
+  maven { url 'https://repo.maven.apache.org/maven2/' }
   maven { url "http://repo.spring.io/libs-milestone-local" }
 }
 


### PR DESCRIPTION
- Ensure Gradle Wrapper is downloaded via https
- This project uses an old version of Gradle in which mavenCentral() and
  jcenter() use http instead of https. This commit switches to use an
  explicit URL so https is used.